### PR TITLE
Bug 1212109 - Implement logging endpoint r=aus,eli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "4.1"
   - "0.12"
-  - "0.10"

--- a/bin/fxos-device-service
+++ b/bin/fxos-device-service
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+if (require.main === module) {
+  require('babel/polyfill');
+  require('../build/service').start();
+}

--- a/package.json
+++ b/package.json
@@ -4,22 +4,26 @@
   "author": "FxOS <dev-fxos@lists.mozilla.org> (#fxos)",
   "description": "A web service that exposes interactions with a connected Firefox OS device",
   "license": "MPL-2.0",
+  "bin": "./bin/fxos-device-service",
   "main": "./build/service.js",
   "repository": "mozilla-b2g/fxos-device-service",
 
   "dependencies": {
     "babel": "^5.8.23",
-    "express": "^4.13.3"
+    "express": "^4.13.3",
+    "mz": "^2.0.0"
   },
 
   "devDependencies": {
     "chai": "^3.3.0",
     "mocha": "^2.3.3",
-    "tcp-port-used": "^0.1.2"
+    "tcp-port-used": "^0.1.2",
+    "watchman": "^0.1.8"
   },
 
   "scripts": {
     "prepublish": "make -j8",
-    "test": "./node_modules/.bin/mocha"
+    "test": "./node_modules/.bin/mocha",
+    "watch": "./node_modules/.bin/watchman src 'npm run prepublish'"
   }
 }

--- a/src/adb/index.js
+++ b/src/adb/index.js
@@ -1,0 +1,7 @@
+let basename = require('path').basename;
+let fs = require('fs');
+
+fs.readdirSync(__dirname)
+  .filter(filename => !__filename.endsWith(filename))
+  .map(filename => basename(filename, '.js'))  // remove file extension
+  .forEach(moduleName => exports[moduleName] = require(`./${moduleName}`));

--- a/src/adb/logcat.js
+++ b/src/adb/logcat.js
@@ -1,0 +1,10 @@
+let PassThrough = require('stream').PassThrough;
+let spawn = require('child_process').spawn;
+
+module.exports = function logcat() {
+  let proc = spawn('adb', ['logcat'], {env: process.env});
+  let stream = new PassThrough();
+  proc.stdout.pipe(stream);
+  proc.stderr.pipe(stream);
+  return {proc: proc, output: stream};
+};

--- a/src/log.js
+++ b/src/log.js
@@ -1,4 +1,10 @@
+let adb = require('./adb');
+
 module.exports = function log(req, res) {
-  // TODO
-  res.status(501).send('501 Not Implemented');
+  let {proc, output} = adb.logcat();
+  output.pipe(res);
+  req.socket.on('close', () => {
+    output.unpipe(res);
+    proc.kill();
+  });
 };

--- a/test/adb
+++ b/test/adb
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+var fs = require('fs');
+
+function main() {
+  var argv = process.argv;
+  var commandName = argv[2];
+  var args = argv.splice(3, argv.length - 3);
+  commands[commandName].apply(null, args);
+}
+
+var commands = {};
+
+/**
+ * Write some random stuff to stdout.
+ */
+commands.logcat = function logcat() {
+  var random = fs.createReadStream('/dev/urandom');
+  random.pipe(process.stdout);
+};
+
+if (require.main === module) {
+  main();
+}

--- a/test/service_test.js
+++ b/test/service_test.js
@@ -1,10 +1,14 @@
+let exec = require('mz/child_process').exec;
 let get = require('./get');
 let http = require('http');
 let service = require('../src/service');
 let tcpPortUsed = require('tcp-port-used');
 
-suite('service', function() {
+suite('service', () => {
   setup(async function() {
+    // Make sure that our fake adb gets used instead of
+    // the real thing.
+    process.env.PATH = `${__dirname}:${process.env.PATH}`;
     service.start(3000);
     await tcpPortUsed.waitUntilUsed(3000);
   });
@@ -24,5 +28,40 @@ suite('service', function() {
     let res = await get('http://localhost:3000/eh');
     res.statusCode.should.equal(404);
     res.body.should.equal('404 Not Found');
+  });
+
+  suite('/log', () => {
+    let log = '';
+
+    setup(done => {
+      let req = http.get('http://localhost:3000/log', res => {
+        function onend() {
+          done(new Error('Log request ended unexpectedly'));
+        }
+
+        res.setEncoding('utf8');
+        res.on('data', chunk => log += chunk);
+        res.on('end', onend);
+
+        // Close the request to /log after some time elapses.
+        setTimeout(async function() {
+          // At this point we should have a logcat process.
+          let [ps] = await exec('ps -au');
+          ps.should.include('adb logcat');
+          res.removeListener('end', onend);
+          req.abort();
+          done();
+        }, 500);
+      });
+    });
+
+    test('should pipe data to browser', () => {
+      log.length.should.be.gt(0);
+    });
+
+    test('should kill adb process when client disconnects', async function() {
+      let [ps] = await exec('ps -au');
+      ps.should.not.include('adb logcat');
+    });
   });
 });


### PR DESCRIPTION
This is starting to get kind of cool! If you do

1. `./node_modules/.bin/fxos-device-service`
2. Open your browser to `http://localhost:8080/log
3. Plug in your device

You'll see all of the logcat output streamed to your browser :).

Note: I am not sure about a good way to test this and some of the other stuff without making an elaborate adb mock...